### PR TITLE
Returning response headers to client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,18 @@ interface RiseDirectiveOptions {
   ErrorClass: new (...args: any[]) => Error;
 }
 
+const FORWARD_RESPONSE_HEADERS = [
+  'set-cookie',
+  'x-callosum-incident-id',
+  'x-callosum-ip',
+  'x-callosum-request-time-us',
+  'x-callosum-trace-id',
+  'x-content-type-options',
+  'x-nginx-localhost',
+  'x-ua-compatible',
+  'x-xss-protection',
+];
+
 export function rise(
   opts: Partial<RiseDirectiveOptions> = {},
 ) {
@@ -131,6 +143,7 @@ export function rise(
 
           fieldConfig.resolve = (source, args, context, info) => {
             let urlToFetch = url;
+            let originalContext = context;
             let body: any;
             const reqHeaders = {
               ...headers,
@@ -169,7 +182,13 @@ export function rise(
                     throw new options.ErrorClass(response.statusText, response.status, e);
                   }
                 }
-
+                // Setting the headers returned from response
+                const responseHeaders: any = response.headers.raw();
+                FORWARD_RESPONSE_HEADERS.forEach((key) => {
+                    if (responseHeaders[key]) {
+                      originalContext.res.setHeader(key, responseHeaders[key]);
+                    }
+                });
                 return (fieldConfig.type.toString() === 'Void')
                   ? response.text() : response.json();
               })


### PR DESCRIPTION
The API called needs to return the header response from the upstream api call
We added the response back manually to context res as part of the fix