### PR TITLE
Refactor try-catch block to fix ApolloError constructor error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,13 +174,15 @@ export function rise(
             })
               .then(async (response) => {
                 if (!response.ok) {
+                  let payload;
                   try {
-                    const payload = await response.json();
-                    const error = (errorroot ? _.get(payload, errorroot) : payload) || {};
-                    throw new options.ErrorClass(response.statusText, response.status, error);
+                    payload = await response.json();
                   } catch (e) {
                     throw new options.ErrorClass(response.statusText, response.status, e);
                   }
+
+                  const error = (errorroot ? _.get(payload, errorroot) : payload) || {};
+                  throw new options.ErrorClass(response.statusText, response.status, error);
                 }
                 // Setting the headers returned from response
                 const responseHeaders: any = response.headers.raw();


### PR DESCRIPTION
Currently in rise we are throwing an Error which is then being caught and the generated error is passed to the ErrorClass as the third argument.

When the ErrorClass is ApolloError it causes Rise to always Error out and throw this error 
```Pass extensions directly as the third argument of the ApolloError constructor: new ApolloError(message, code, {myExt: value}), not `new ApolloError(message, code, {extensions: {myExt: value}})```

refactored the try catch block to handle the same.

For eg : 
```
const error = new ApolloError('Something went wrong', 'SERVER_ERROR', {
customProperty: 'customValue',
});

throw new ApolloError('Something went wrong', 'SERVER_ERROR', error);```

throws the same error