### PR TITLE
SCAL-161500 : Handling of text and json response in payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtspot/rise",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Rise above the REST with GraphQL",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,11 +176,16 @@ export function rise(
                 if (!response.ok) {
                   let payload;
                   try {
-                    payload = await response.json();
+                    const contentType = response.headers.get('Content-Type');
+                    const isTextContent = contentType && contentType.includes('text');
+                    if (isTextContent) {
+                      payload = { [errorroot]: { message: await response.text() } };
+                    } else {
+                      payload = await response.json();
+                    }
                   } catch (e) {
                     throw new options.ErrorClass(response.statusText, response.status, e);
                   }
-
                   const error = (errorroot ? _.get(payload, errorroot) : payload) || {};
                   throw new options.ErrorClass(response.statusText, response.status, error);
                 }

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -99,7 +99,7 @@
       method: "POST",
       postbody: """
       {
-        "user_identifier": "<%= args.indentifier%>"
+        "user_identifier": "<%= args.identifier%>"
       }
       """
     ),


### PR DESCRIPTION
SCAL-161500

Currently rise errors out and sends the following error
<img width="1022" alt="Screenshot 2023-06-28 at 6 14 37 PM" src="https://github.com/thoughtspot/rise/assets/42416647/3c252b36-e5eb-4dcb-a25f-fc98385ae0ef">

Udpated error message
<img width="1036" alt="Screenshot 2023-06-28 at 6 12 43 PM" src="https://github.com/thoughtspot/rise/assets/42416647/d7b12141-fb86-4476-839e-8e183049e73d">

