### PR TITLE
SCAL-321502-200-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtspot/rise",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Rise above the REST with GraphQL",
   "main": "dist/index.js",
   "scripts": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -175,12 +175,45 @@ export async function parseJsonOrThrow(response, ErrorClass) {
     let payload;
     try {
         payload = await response.json();
-    } catch (err) {
-        throw new ErrorClass(response.statusText, response.status, err);
+    } catch {
+        // Body isn't JSON (e.g. an HTML error page). Don't attach the raw
+        // parse error — its message leaks the internal downstream URL and
+        // parser debug detail to API clients. The status line is the signal.
+        throw new ErrorClass(response.statusText, response.status);
     }
     throw new ErrorClass(
         response.statusText,
         response.status,
         payload.errors || payload,
+    );
+}
+
+// Apollo string error-codes -> HTTP status, for downstream GraphQL errors
+// returned as HTTP 200 with an `errors` array.
+const GQL_ERROR_CODE_TO_STATUS: Record<string, number> = {
+    UNAUTHENTICATED: 401,
+    FORBIDDEN: 403,
+    BAD_USER_INPUT: 400,
+    GRAPHQL_PARSE_FAILED: 400,
+    GRAPHQL_VALIDATION_FAILED: 400,
+};
+
+// Derive the real HTTP status from a downstream GraphQL `errors` array. The
+// status is carried in the first error's extensions — numeric `code` or
+// `upstreamResponse.status` (rise rest-resolver errors, e.g. 403), or an
+// Apollo error-code string. App-level numeric codes (e.g. 10002) are not
+// valid HTTP statuses and fall through to 500.
+export function deriveGqlErrorStatus(errors: any[]): number {
+    const [firstError] = errors || [];
+    const ext = firstError?.extensions ?? {};
+    const rawCode = ext.code ?? firstError?.code;
+    const isHttpErrorStatus = (n: number) =>
+        Number.isInteger(n) && n >= 400 && n <= 599;
+    return (
+        [Number(ext.upstreamResponse?.status), Number(rawCode)].find(
+            isHttpErrorStatus,
+        ) ||
+        GQL_ERROR_CODE_TO_STATUS[rawCode] ||
+        500
     );
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -203,7 +203,7 @@ const GQL_ERROR_CODE_TO_STATUS: Record<string, number> = {
 // `upstreamResponse.status` (rise rest-resolver errors, e.g. 403), or an
 // Apollo error-code string. App-level numeric codes (e.g. 10002) are not
 // valid HTTP statuses and fall through to 500.
-export function deriveGqlErrorStatus(errors: any[]): number {
+export function deriveGqlErrorStatus(errors?: any[]): number {
     const [firstError] = errors || [];
     const ext = firstError?.extensions ?? {};
     const rawCode = ext.code ?? firstError?.code;

--- a/src/gql-resolver.ts
+++ b/src/gql-resolver.ts
@@ -11,6 +11,7 @@ import {
     renameFieldsInQuery,
     reverseKeyValue,
     parseJsonOrThrow,
+    deriveGqlErrorStatus,
 } from './common';
 import { generateBodyFromTemplate } from './rest-resolver';
 
@@ -131,12 +132,13 @@ export function gqlResolver(
             })
             .then((response) => {
                 if (response.errors) {
-                    // TODO: Update the error class to passthough error context more correctly.
-                    throw new options.ErrorClass(
-                        response.statusText,
-                        response.status,
-                        response.errors,
-                    );
+                    // `response` here is the parsed GraphQL body (HTTP 200) —
+                    // the failure status lives in the error's extensions, not
+                    // on the (undefined) response.status/statusText.
+                    const status = deriveGqlErrorStatus(response.errors);
+                    const message =
+                        response.errors[0]?.message || 'Downstream GraphQL error';
+                    throw new options.ErrorClass(message, status, response.errors);
                 }
                 return response;
             })

--- a/test/index.ts
+++ b/test/index.ts
@@ -284,6 +284,15 @@ describe('deriveGqlErrorStatus', () => {
   test('defaults to 500 when no recognizable code is present', () => {
     expect(deriveGqlErrorStatus([{ message: 'boom' }])).toBe(500);
   });
+
+  test('falls back to a top-level error code when extensions are absent', () => {
+    expect(deriveGqlErrorStatus([{ message: 'denied', code: 403 }])).toBe(403);
+  });
+
+  test('defaults to 500 for empty or missing errors input', () => {
+    expect(deriveGqlErrorStatus([])).toBe(500);
+    expect(deriveGqlErrorStatus(undefined)).toBe(500);
+  });
 });
 
 describe('Should call the Target', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -7,7 +7,7 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import fs from 'fs';
 import path from 'path';
 import { rise } from '../src/index';
-import { mapKeysDeep, parseResponseKeyFormat, reverseKeyValue, renameFieldsInQuery, parseJsonOrThrow } from '../src/common';
+import { mapKeysDeep, parseResponseKeyFormat, reverseKeyValue, renameFieldsInQuery, parseJsonOrThrow, deriveGqlErrorStatus } from '../src/common';
 
 const typeDefs = fs.readFileSync(path.join(__dirname, './schema.graphql'), 'utf8');
 
@@ -223,7 +223,9 @@ describe('parseJsonOrThrow', () => {
   test('preserves the status when the body is empty / not valid JSON', async () => {
     // Reproduces the Eureka Agent 403-with-empty-body case: response.json()
     // throws a SyntaxError, but the HTTP status must still be preserved
-    // (instead of surfacing as a status-less 500).
+    // (instead of surfacing as a status-less 500). The raw parse error must
+    // NOT be attached — its message leaks the internal downstream URL and
+    // parser debug detail to API clients.
     const parseError = new SyntaxError('Unexpected end of JSON input');
     const response = makeResponse({
       status: 403,
@@ -236,8 +238,51 @@ describe('parseJsonOrThrow', () => {
     ).rejects.toMatchObject({
       status: 403,
       statusText: 'Forbidden',
-      payload: parseError,
+      payload: undefined,
     });
+  });
+});
+
+describe('deriveGqlErrorStatus', () => {
+  // Downstream (internal /prism) reports a failing eureka call as HTTP 200
+  // with a GraphQL `errors` array — the real status lives in extensions.
+  test('extracts a numeric extensions.code (e.g. rest-resolver 403)', () => {
+    expect(
+      deriveGqlErrorStatus([{ message: 'denied', extensions: { code: 403 } }]),
+    ).toBe(403);
+  });
+
+  test('extracts nested extensions.upstreamResponse.status (UPSTREAM_FAILURE)', () => {
+    expect(
+      deriveGqlErrorStatus([
+        {
+          message: 'Request failed with status code 403',
+          extensions: {
+            code: 'UPSTREAM_FAILURE',
+            upstreamResponse: { status: 403 },
+          },
+        },
+      ]),
+    ).toBe(403);
+  });
+
+  test('maps Apollo string error-codes to their HTTP status', () => {
+    expect(
+      deriveGqlErrorStatus([{ extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }]),
+    ).toBe(400);
+    expect(
+      deriveGqlErrorStatus([{ extensions: { code: 'UNAUTHENTICATED' } }]),
+    ).toBe(401);
+  });
+
+  test('clamps app-level numeric codes (e.g. 10002) that are not HTTP statuses to 500', () => {
+    expect(
+      deriveGqlErrorStatus([{ extensions: { code: 10002 } }]),
+    ).toBe(500);
+  });
+
+  test('defaults to 500 when no recognizable code is present', () => {
+    expect(deriveGqlErrorStatus([{ message: 'boom' }])).toBe(500);
   });
 });
 


### PR DESCRIPTION
200 - error paths covered , previous pr covered non-200 error paths - but graphql has 200-hapy error paths. 
Scenario | Pre-fix | Now | Verified
-- | -- | -- | --
Happy path (admin) | 200 | 200 + data | live ✅
Privilege denied (eureka → UPSTREAM_FAILURE) | 500 {} | 403 | live ✅
Bad/expired token (401 HTML downstream) | 500/leak | 401, clean body | live ✅
Downstream validation error (200+errors) | 500 {} | 400 | live ✅
503 down, numeric-403, app-code→500 clamp | 500/undefined | correct | harness 12/12 ✅
Unit tests | — | 44/44 ✅
Internal-URL/debug leakage in bodies | leaked | gone | live ✅
Spec/SDK impact | — | none | verified

